### PR TITLE
Add Docker container support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+media/
+db.sqlite3
+*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DATABASE_URL=sqlite:///db.sqlite3
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+RUN chmod +x build.sh && ./build.sh
+
+EXPOSE 8000
+CMD ["gunicorn", "SAManager.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# SA-Backend
+
+This project contains the backend for the "SA" application built with Django.
+
+## Container Usage
+
+1. **Build the image**
+
+   ```bash
+   docker build -t sa-backend .
+   ```
+
+2. **Run the container**
+
+   ```bash
+   docker run -p 8000:8000 sa-backend
+   ```
+
+The container exposes port `8000` and starts the application using `gunicorn SAManager.wsgi:application`.


### PR DESCRIPTION
## Summary
- create Dockerfile to containerize the Django project
- add `.dockerignore` to avoid copying unnecessary files
- document how to build and run the container in `README.md`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848ca7c0bc88321bed58757092d67c7