### PR TITLE
Update allowed hosts env and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ This project contains the backend for the "SA" application built with Django.
    ```
 
 The container exposes port `8000` and starts the application using `gunicorn SAManager.wsgi:application`.
+
+## Deployment with Coolify
+
+When deploying to Coolify, set the `DJANGO_ALLOWED_HOSTS` environment variable to a
+comma-separated list of allowed domain names.

--- a/SAManager/settings.py
+++ b/SAManager/settings.py
@@ -20,7 +20,7 @@ MEDIA_ROOT = BASE_DIR / 'media'
 SECRET_KEY = 'django-insecure-c@b7tyhnjq3a0(=l&l-&s=n)cw2kmdt$u324vn3rj@+v7ke&2%'
 
 DEBUG = os.environ.get('DEBUG', 'False') == 'True'
-ALLOWED_HOSTS = ['https://sa-backend-j2yy.onrender.com/', '.onrender.com']
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "").split(",")
 
 
 # Application definition


### PR DESCRIPTION
## Summary
- parse a comma-separated list from `DJANGO_ALLOWED_HOSTS`
- document how to set `DJANGO_ALLOWED_HOSTS` when deploying with Coolify

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6848cc7598fc8321bf20f4ed28dc36d6