### PR TITLE
Fix asgi settings module path

### DIFF
--- a/SAManager/asgi.py
+++ b/SAManager/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'PortfolioManager.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'SAManager.settings')
 
 application = get_asgi_application()


### PR DESCRIPTION
## Summary
- correct `DJANGO_SETTINGS_MODULE` in `SAManager/asgi.py`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848cd1ff0f483219b557e2802756994