### PR TITLE
Read SECRET_KEY from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ The container exposes port `8000` and starts the application using `gunicorn SAM
 ## Deployment with Coolify
 
 When deploying to Coolify, set the `DJANGO_ALLOWED_HOSTS` environment variable to a
-comma-separated list of allowed domain names.
+comma-separated list of allowed domain names. Additionally, define the
+`SECRET_KEY` environment variable with the Django secret key used in production.

--- a/SAManager/settings.py
+++ b/SAManager/settings.py
@@ -17,7 +17,8 @@ MEDIA_ROOT = BASE_DIR / 'media'
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-c@b7tyhnjq3a0(=l&l-&s=n)cw2kmdt$u324vn3rj@+v7ke&2%'
+# This value is required and must be provided via the environment.
+SECRET_KEY = os.environ['SECRET_KEY']
 
 DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "").split(",")


### PR DESCRIPTION
## Summary
- read `SECRET_KEY` from environment in Django settings
- document new required variable in deployment instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e1d7419e88321acca7fb19dfa25f8