### PR TITLE
Update API domain

### DIFF
--- a/SAManager/settings.py
+++ b/SAManager/settings.py
@@ -84,7 +84,7 @@ WSGI_APPLICATION = 'SAManager.wsgi.application'
 
 CORS_ALLOWED_ORIGINS = [
     "https://sidney-art.com",
-    "https://api-sidney-art.com",    
+    "https://api.sidney-art.com",    
 ]
 
 CSRF_TRUSTED_ORIGINS = ['https://api.sidney-art.com']


### PR DESCRIPTION
## Summary
- correct API domain in settings

## Testing
- `pytest -q`
- `python manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e3d0a116483219621b665fa029209