### PR TITLE
Make SSL redirect configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ The container exposes port `8000` and starts the application using `gunicorn SAM
 When deploying to Coolify, set the `DJANGO_ALLOWED_HOSTS` environment variable to a
 comma-separated list of allowed domain names. Additionally, define the
 `SECRET_KEY` environment variable with the Django secret key used in production.
+
+Set `SECURE_SSL_REDIRECT` to `False` if your reverse proxy is misconfigured and
+causes redirect loops. The default value is `True`.

--- a/SAManager/settings.py
+++ b/SAManager/settings.py
@@ -137,4 +137,4 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-SECURE_SSL_REDIRECT = True
+SECURE_SSL_REDIRECT = os.environ.get('SECURE_SSL_REDIRECT', 'True') == 'True'


### PR DESCRIPTION
## Summary
- allow disabling SSL redirects via `SECURE_SSL_REDIRECT` env var
- document the variable in the README

## Testing
- `python manage.py check` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e3db16b548321869d7189d753bb5c